### PR TITLE
Compatibility fix for newer versions of RPi.GPIO needed for RPi2

### DIFF
--- a/octoprint_octoglow/piglow.py
+++ b/octoprint_octoglow/piglow.py
@@ -20,11 +20,20 @@ bus = 0
 class PiGlow:
 
     def __init__(self):
-        if rpi.RPI_REVISION == 1:
+        if hasattr(rpi, "RPI_INFO") and "P1_REVISION" in rpi.RPI_INFO:
+            # RPi.GPIO >= 0.5.10
+            revision = rpi.RPI_INFO["P1_REVISION"]
+        elif hasattr(rpi, "RPI_REVISION"):
+            # RPi.GPIO < 0.5.10
+            revision = rpi.RPI_REVISION
+        else:
+            print "Unable to determine Raspberry Pi revision."
+
+        if revision == 1:
             i2c_bus = 0
-        elif rpi.RPI_REVISION == 2:
+        elif revision == 2:
             i2c_bus = 1
-        elif rpi.RPI_REVISION == 3:
+        elif revision == 3:
             i2c_bus = 1
         else:
             print "Unable to determine Raspberry Pi revision."


### PR DESCRIPTION
RPi.GPIO is incompatible to RPi2s until version 0.5.10. 
That version however deprecates `RPI_REVISION` in 
favor of `RPI_INFO["P1_REVISION"]`, leading to errors 
upon import.

This patch checks for the presence of the attributes
and uses whatever variant of the two is available.

Ported from https://github.com/Boeeerb/PiGlow/pull/21
